### PR TITLE
Fix code scanning alert no. 16: Potentially unsafe quoting

### DIFF
--- a/os/gview/gview_parse.go
+++ b/os/gview/gview_parse.go
@@ -430,7 +430,7 @@ func (view *View) searchFile(ctx context.Context, file string) (path string, fol
 	if path == "" {
 		buffer := bytes.NewBuffer(nil)
 		if view.searchPaths.Len() > 0 {
-			buffer.WriteString(fmt.Sprintf("cannot find template file \"%s\" in following paths:", file))
+			buffer.WriteString(fmt.Sprintf("cannot find template file %s in following paths:", strconv.Quote(file)))
 			view.searchPaths.RLockFunc(func(array []string) {
 				index := 1
 				for _, searchPath := range array {
@@ -445,12 +445,12 @@ func (view *View) searchFile(ctx context.Context, file string) (path string, fol
 				}
 			})
 		} else {
-			buffer.WriteString(fmt.Sprintf("cannot find template file \"%s\" with no path set/add", file))
+			buffer.WriteString(fmt.Sprintf("cannot find template file %s with no path set/add", strconv.Quote(file)))
 		}
 		if errorPrint() {
 			glog.Error(ctx, buffer.String())
 		}
-		err = gerror.NewCodef(gcode.CodeInvalidParameter, `template file "%s" not found`, file)
+		err = gerror.NewCodef(gcode.CodeInvalidParameter, `template file %s not found`, strconv.Quote(file))
 	}
 	return
 }


### PR DESCRIPTION
Fixes [https://github.com/houseme/gf/security/code-scanning/16](https://github.com/houseme/gf/security/code-scanning/16)

To fix the problem, we need to ensure that any special characters in the `file` variable are properly escaped before being included in the formatted string. This can be achieved by using a function that escapes special characters, such as `strconv.Quote`, which will handle escaping quotes and other special characters.

- Use `strconv.Quote` to escape the `file` variable before including it in the formatted string.
- Update the relevant lines in the `searchFile` function to use the escaped version of the `file` variable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
